### PR TITLE
Added default constructor and setDeviceHandle, so the class can be used as class member variable

### DIFF
--- a/include/mcp2515.h
+++ b/include/mcp2515.h
@@ -461,7 +461,9 @@ class MCP2515
         void prepareId(uint8_t *buffer, const bool ext, const uint32_t id);
 
     public:
+        MCP2515();
         MCP2515(spi_device_handle_t *s);
+        void setDeviceHandle(spi_device_handle_t *s);
         ERROR reset(void);
         ERROR setConfigMode();
         ERROR setListenOnlyMode();

--- a/mcp2515.cpp
+++ b/mcp2515.cpp
@@ -16,10 +16,19 @@ const struct MCP2515::RXBn_REGS MCP2515::RXB[N_RXBUFFERS] = {
     {MCP_RXB1CTRL, MCP_RXB1SIDH, MCP_RXB1DATA, CANINTF_RX1IF}
 };
 
+MCP2515::MCP2515()
+{
+    MCP2515(NULL);
+}
+
 MCP2515::MCP2515(spi_device_handle_t *s)
 {
     spi = s;
     interrupt_mask = CANINTF_RX0IF | CANINTF_RX1IF | CANINTF_ERRIF | CANINTF_MERRF;
+}
+
+void MCP2515::setDeviceHandle(spi_device_handle_t *s) {
+    spi = s;
 }
 
 MCP2515::ERROR MCP2515::reset(void)


### PR DESCRIPTION
Using the class MCP2515 in a class as member variable requires a default constructor, or an active SPI handle. Both not available at class creation. Therefore added these methods to overcome this issue.

```c++
class CAN {
private:
    spi_device_handle_t handleCan0;
    spi_device_handle_t handleCan1;
    spi_device_handle_t handleCan2;
    
    MCP2515 can0;
    MCP2515 can1;
    MCP2515 can2;

    /* Protected constructor in order to create a singleton class. */
    CAN () {   
    }

public:
   void setup () {
        this->can0.setDeviceHandle(&this->handleCan0);
        this->can0.reset();
        this->can0.setBitrate(CAN_250KBPS, MCP_8MHZ);
        this->can0.setNormalMode();
        
        this->can1.setDeviceHandle(&this->handleCan1);
        this->can1.reset();
        this->can1.setBitrate(CAN_250KBPS, MCP_8MHZ);
        this->can0.setNormalMode();

        this->can2.setDeviceHandle(&this->handleCan2);
        this->can2.reset();
        this->can2.setBitrate(CAN_250KBPS, MCP_8MHZ);
        this->can0.setNormalMode();
    }

....
```